### PR TITLE
support custom jupycent buffer set.

### DIFF
--- a/plugin/jupycent.vim
+++ b/plugin/jupycent.vim
@@ -74,6 +74,9 @@ function s:jupycent_set_buffer(filename, jupycent_file_exists)  "{{{
       execute 'normal! g`"zvzz' |
     endif
   endif
+  if exists("*CustomJupycentBufferSet")
+    call CustomJupycentBufferSet()
+  endif
 endfunction  "}}}
 
 function! s:write_to_ipynb() abort  "{{{


### PR DESCRIPTION
This commit combine a user-defined `CustomJupycentBufferSet` function can custom jupycent buffer set more.

Below is a sample:

```
function! CustomJupycentBufferSet()
    hi clear JupycentCell
    hi JupycentCell cterm=bold,italic gui=bold,italic term=bold ctermfg=241 guifg=#665c54
    set fo=croql
endfunction
```